### PR TITLE
change UX/UI's second deliverable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ development process.
   - Lesson Plan:
     [Design Thinking](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/lesson-plans/design-thinking.md)
   - Deliverable:
-    [Begin the Practical Case](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/practical-case.md)
+    [Practical Case](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/practical-case.md)
 - **Week 2**: Chapters 2, 3
   - Lesson Plan:
     [Gestalt Principles & Figma](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/lesson-plans/gestalt-and-figma.md)
   - Deliverable:
-    [Complete the Practical Case](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/practical-case.md)
+    [Co-Design your Home Page](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/co-design-your-home-page)
 
 ### [4. Welcome to JS](https://github.com/hackyourfuturebelgium/welcome-to-js): 3 weeks
 
@@ -142,7 +142,7 @@ development process.
 Learn to read small programs, and to write code that other people can
 understand.
 
-- **Week 1**: Chapters 0, 1, 2 k
+- **Week 1**: Chapters 0, 1, 2
 
   - Lesson Plan:
     [Computers and Developers](https://github.com/HackYourFutureBelgium/welcome-to-js/blob/master/lesson-plans/computers-and-developers)

--- a/admin/modules.yml
+++ b/admin/modules.yml
@@ -66,15 +66,14 @@ path:
       - **Week 1**: Chapter 1
         - Lesson Plan: [Design
       Thinking](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/lesson-plans/design-thinking.md)
-        - Deliverable: [Begin the Practical
+        - Deliverable: [Practical
       Case](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/practical-case.md)
 
       - **Week 2**: Chapters 2, 3
         - Lesson Plan: [Gestalt Principles &
       Figma](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/lesson-plans/gestalt-and-figma.md)
-        - Deliverable: [Complete the Practical
-      Case](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/practical-case.md)
-
+        - Deliverable: [Co-Design your Home
+      Page](https://github.com/HackYourFutureBelgium/ux-ui-design/blob/master/deliverables/co-design-your-home-page)
     url: https://github.com/hackyourfuturebelgium/ux-ui-design
     weeks: 2
     state: open
@@ -98,7 +97,6 @@ path:
         - Lesson Plan: [Writing and
       Reviewing](https://github.com/HackYourFutureBelgium/welcome-to-js/blob/master/lesson-plans/writing-and-reviewing)
         - Study Priorities: _Developing Programs_
-
     url: https://github.com/hackyourfuturebelgium/welcome-to-js
     weeks: 3
     milestone: 5


### PR DESCRIPTION
Changing the second UX/UI deliverable to the co-designed home page.  

I've also updated the deliverable's description in the module repo so it's about Figma and not development.  building the page is suggested to keep practicing HTML & CSS during the JS modules

<!--
  make this PR easy to find:

  - assign and add reviewers
  - add any helpful labels
  - connect it to a milestone (if necessary)
  - link it with an issue (if necessary)
-->

<!-- describe your PR -->

## Checklists

### General Checks

- [x] the branch is up to date with `main`/`master`
- [x] the code works when pulled and run locally
- [x] All CI checks pass
- [x] all conflicts are resolved (if any)
- [x] PR has a descriptive title
- [x] PR has appropriate labels and milestones for easy identification
- [x] PR it is assigned to the owner
- [x] reviewers are assigned
- [x] the PR contributes only one focused change
- [x] It is in the appropriate column in the project board (if necessary)
- [x] has short and clear description
- [x] is linked to an issue (if it is related)
- [x] feedback is addressed (if any and if it is appropriate feedback.)

### Markdown

<!-- markdown-specific checks -->

- [x] the markdown source is formatted
- [x] spelling and grammar is correct in all text
- [x] The markdown looks correct when you preview the file
- [x] all links and images work
- [x] any embedded code snippets are formatted
